### PR TITLE
support representing constructor calls as method calls

### DIFF
--- a/dataflow/src/main/java/org/checkerframework/dataflow/expression/MethodCall.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/expression/MethodCall.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.StringJoiner;
 
-import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.type.TypeMirror;
 
@@ -146,10 +145,6 @@ public class MethodCall extends JavaExpression {
         if (!(obj instanceof MethodCall)) {
             return false;
         }
-        if (method.getKind() == ElementKind.CONSTRUCTOR) {
-            // No two constructor instances are equal.
-            return false;
-        }
         MethodCall other = (MethodCall) obj;
         return method.equals(other.method)
                 && receiver.equals(other.receiver)
@@ -158,10 +153,6 @@ public class MethodCall extends JavaExpression {
 
     @Override
     public int hashCode() {
-        if (method.getKind() == ElementKind.CONSTRUCTOR) {
-            // No two constructor instances have the same hashcode.
-            return System.identityHashCode(this);
-        }
         return Objects.hash(method, receiver, arguments);
     }
 

--- a/framework/src/main/java/org/checkerframework/framework/util/JavaExpressionParseUtil.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/JavaExpressionParseUtil.java
@@ -1191,7 +1191,7 @@ public class JavaExpressionParseUtil {
         private @CompilerMessageKey String errorKey;
 
         /** The arguments to the error message key. */
-        public final Object[] args;
+        public final transient Object[] args;
 
         /**
          * Create a new JavaExpressionParseException.


### PR DESCRIPTION
This PR gets rid of the artificial restriction in the checker framework that prevents `MethodCall`s from being used to represent constructor calls. I want to lift his restriction for my SMT analysis in the property checker.

So far I have not verified that this has 0 effect on other parts of the checker framework (i.e. whether something else _relies_ on the previous behaviour), but from surface level tests everything seems to work as before.